### PR TITLE
Fix multi-select dropdowns flip-flopping between empty and not

### DIFF
--- a/LibAddonMenu-2.0/controls/dropdown.lua
+++ b/LibAddonMenu-2.0/controls/dropdown.lua
@@ -76,6 +76,7 @@ local function UpdateMultiSelectSelected(control, values)
 
     local dropdown = control.dropdown
     dropdown.m_selectedItemData = {}
+    dropdown.m_multiSelectItemData = {}
 
     local choicesValues = data.choicesValues
     local usesChoicesValues = choicesValues ~= nil


### PR DESCRIPTION
https://github.com/Baertram/ESO-LibAddonMenu/blob/master/LibAddonMenu-2.0/controls/dropdown.lua#L73-L97 currently only clears dropdown.m_selectedItemData, but m_enableMultiSelect dropdowns use m_multiSelectItemData instead. Because that isn't cleared, dropdown:SetSelectedItemByEval resolves eventually into SelectItem (which, in /EsoUI/Libraries/ZO_ComboBox/ZO_ComboBox.lua:341, self:RemoveItemFromSelected(item) if the item was already self:IsItemSelected(item) ). So ultimately, UpdateMultiSelectSelected currently untoggles everything when called (for multiSelect only).
